### PR TITLE
Revert "Add keygen autorun to tests"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
           toolchain:            1.60.0
           override:             true
           components:           rustfmt, clippy
+      - name:                   Run keygen
+        run:                    ./keygen.sh
       - name: Grab cached files
         uses: actions/cache@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /procgov
 .DS_Store
 *.json.txt
-lib/test-data/*
-!lib/test-data/README
+lib/localhost.pem
+localhost.crt
+localhost.key

--- a/keygen.sh
+++ b/keygen.sh
@@ -3,6 +3,4 @@ openssl req -x509 -out localhost.crt -keyout localhost.key \
     -subj '/CN=localhost' -extensions EXT -config <( \
        printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth,clientAuth")
 
-echo `pwd`
-cat localhost.crt localhost.key > $1
-rm localhost.crt localhost.key
+cat localhost.crt localhost.key > lib/localhost.pem

--- a/lib/src/grpc_connector.rs
+++ b/lib/src/grpc_connector.rs
@@ -53,7 +53,12 @@ impl GrpcConnector {
                 let mut roots = RootCertStore::empty();
 
                 #[cfg(test)]
-                add_test_cert_to_roots(&mut roots);
+                {
+                    let fd = std::fs::File::open("localhost.pem").unwrap();
+                    let mut buf = std::io::BufReader::new(&fd);
+                    let certs = rustls_pemfile::certs(&mut buf).unwrap();
+                    roots.add_parsable_certificates(&certs);
+                }
 
                 #[cfg(not(test))]
                 let roots = RootCertStore::empty();
@@ -505,12 +510,4 @@ impl GrpcConnector {
             Err(format!("Error: {:?}", sendresponse))
         }
     }
-}
-
-#[cfg(test)]
-fn add_test_cert_to_roots(roots: &mut RootCertStore) {
-    let fd = std::fs::File::open(crate::lightclient::test_server::TEST_PEMFILE_PATH).unwrap();
-    let mut buf = std::io::BufReader::new(&fd);
-    let certs = rustls_pemfile::certs(&mut buf).unwrap();
-    roots.add_parsable_certificates(&certs);
 }

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -31,9 +31,6 @@ use zcash_primitives::transaction::{Transaction, TxId};
 use super::lightclient_config::LightClientConfig;
 use super::LightClient;
 
-pub(crate) const TEST_PEMFILE_PATH: &'static str = "test-data/localhost.pem";
-static KEYGEN: std::sync::Once = std::sync::Once::new();
-
 pub async fn create_test_server(
     https: bool,
 ) -> (
@@ -43,16 +40,6 @@ pub async fn create_test_server(
     oneshot::Sender<()>,
     JoinHandle<()>,
 ) {
-    KEYGEN.call_once(|| {
-        assert!(std::process::Command::new("sh")
-            .args(["keygen.sh", TEST_PEMFILE_PATH])
-            //For some reason, openssl, when successfully
-            //generating a key, prints to stderr, not stdout
-            .stderr(std::process::Stdio::null())
-            .status()
-            .unwrap()
-            .success())
-    });
     let (ready_transmitter, ready_receiver) = oneshot::channel();
     let (stop_transmitter, stop_receiver) = oneshot::channel();
     let mut stop_fused = stop_receiver.fuse();
@@ -104,17 +91,18 @@ pub async fn create_test_server(
         let nameuri: std::string::String = uri.replace("https://", "").replace("http://", "").parse().unwrap();
         let listener = tokio::net::TcpListener::bind(nameuri).await.unwrap();
         let tls_acceptor = if https {
+            let file = "localhost.pem";
             use std::fs::File;
             use std::io::BufReader;
             let (cert, key) = (
                 tokio_rustls::rustls::Certificate(
-                    rustls_pemfile::certs(&mut BufReader::new(File::open(TEST_PEMFILE_PATH).unwrap()))
+                    rustls_pemfile::certs(&mut BufReader::new(File::open(file).unwrap()))
                         .unwrap()
                         .pop()
                         .unwrap(),
                 ),
                 tokio_rustls::rustls::PrivateKey(
-                    rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(File::open(TEST_PEMFILE_PATH).unwrap()))
+                    rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(File::open(file).unwrap()))
                         .unwrap()
                         .pop()
                         .expect("empty vec of private keys??"),

--- a/lib/test-data/README
+++ b/lib/test-data/README
@@ -1,1 +1,0 @@
-By default, failing test state is not erased.


### PR DESCRIPTION
Looks like tests that passed locally, failed on the runner. We didn't wait for CI to finish.