### PR TITLE
Insert into td

### DIFF
--- a/lib/src/blaze/test_utils.rs
+++ b/lib/src/blaze/test_utils.rs
@@ -164,7 +164,7 @@ impl FakeTransaction {
         cout.epk = epk;
         cout.ciphertext = enc_ciphertext[..52].to_vec();
 
-        //self.td.sapling_bundle().unwrap().shielded_outputs.push(od);
+        self.td.sapling_bundle().unwrap().shielded_outputs.push(od);
         self.compact_transaction.outputs.push(cout);
 
         note
@@ -202,7 +202,7 @@ impl FakeTransaction {
         hash160.update(Sha256::digest(&pk.serialize()[..].to_vec()));
 
         let taddr_bytes = hash160.finalize();
-        /*self.td
+        self.td
             .transparent_bundle()
             .expect("Construction should guarantee Some")
             .vout
@@ -210,13 +210,12 @@ impl FakeTransaction {
                 value: Amount::from_u64(value).unwrap(),
                 script_pubkey: TransparentAddress::PublicKey(taddr_bytes.try_into().unwrap()).script(),
             });
-        */
+
         self.taddrs_involved.push(taddr)
     }
 
     // Spend the given utxo
     pub fn add_t_input(&mut self, transaction_id: TxId, n: u32, taddr: String) {
-        /*
         self.td
             .transparent_bundle()
             .expect("Depend on construction for Some.")
@@ -225,7 +224,7 @@ impl FakeTransaction {
                 prevout: OutPoint::new(*(transaction_id.as_ref()), n),
                 script_sig: Script { 0: vec![] },
                 sequence: 0,
-            });*/
+            });
         self.taddrs_involved.push(taddr);
     }
 
@@ -395,7 +394,7 @@ impl FakeCompactBlockList {
         let (compact_transaction, transaction, taddrs) = fake_transaction.into_transaction();
 
         let height = self.next_height;
-        //self.transactions.push((transaction, height, taddrs));
+        self.transactions.push((transaction, height, taddrs));
         self.add_empty_block().add_transactions(vec![compact_transaction]);
 
         (transaction, height)

--- a/lib/src/blaze/test_utils.rs
+++ b/lib/src/blaze/test_utils.rs
@@ -258,7 +258,8 @@ impl FakeTransaction {
 
     pub fn into_transaction(mut self) -> (CompactTx, Transaction, Vec<String>) {
         let transaction = self.td.freeze().unwrap();
-        self.compact_transaction.hash = Vec::from(*(transaction.txid().clone().as_ref()));
+        let txid = transaction.txid().clone();
+        self.compact_transaction.hash = Vec::from(*(txid.as_ref()));
 
         (self.compact_transaction, transaction, self.taddrs_involved)
     }

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -22,7 +22,7 @@ use zcash_primitives::{
 
 use crate::{grpc_connector::GrpcConnector, lightclient::checkpoints};
 
-pub const DEFAULT_SERVER: &str = "https://lwdv3.zecwallet.co";
+pub const DEFAULT_SERVER: &str = "http://127.0.0.1:9067";
 pub const WALLET_NAME: &str = "zecwallet-light-wallet.dat";
 pub const LOGFILE_NAME: &str = "zecwallet-light-wallet.debug.log";
 pub const ANCHOR_OFFSET: [u32; 5] = [4, 0, 0, 0, 0];

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -22,7 +22,7 @@ use zcash_primitives::{
 
 use crate::{grpc_connector::GrpcConnector, lightclient::checkpoints};
 
-pub const DEFAULT_SERVER: &str = "http://127.0.0.1:9067";
+pub const DEFAULT_SERVER: &str = "https://lwdv3.zecwallet.co";
 pub const WALLET_NAME: &str = "zecwallet-light-wallet.dat";
 pub const LOGFILE_NAME: &str = "zecwallet-light-wallet.debug.log";
 pub const ANCHOR_OFFSET: [u32; 5] = [4, 0, 0, 0, 0];


### PR DESCRIPTION
The `self.td.sapling_bundle()` returns an immutable ref, but `self.td` itself is `pub`.

So the hack:

  1.  Grab the original immutable bundle by ref.
  2.  clone it to a `mut` var
  3.  Inject the new value into into a new TransactionData (by constructing it)
  4. Bind that fresh `td` to the `pub` `self.td` field.
  g. profit