### PR TITLE
add clean shutdown and use it

### DIFF
--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -204,6 +204,11 @@ pub async fn create_test_server(
     (data, config, ready_receiver, stop_transmitter, h1)
 }
 
+pub async fn clean_shutdown(stop_transmitter: oneshot::Sender<()>, server_thread_handle: JoinHandle<()>) {
+    stop_transmitter.send(()).unwrap();
+    server_thread_handle.await.unwrap();
+}
+
 pub async fn mine_random_blocks(
     fcbl: &mut FakeCompactBlockList,
     data: &Arc<RwLock<TestServerData>>,

--- a/lib/src/lightclient/tests.rs
+++ b/lib/src/lightclient/tests.rs
@@ -26,7 +26,7 @@ use crate::blaze::test_utils::{FakeCompactBlockList, FakeTransaction};
 use crate::lightclient::testmocks;
 
 use crate::compact_formats::{CompactOutput, CompactTx, Empty};
-use crate::lightclient::test_server::{create_test_server, mine_pending_blocks, mine_random_blocks};
+use crate::lightclient::test_server::{clean_shutdown, create_test_server, mine_pending_blocks, mine_random_blocks};
 use crate::lightclient::LightClient;
 use crate::lightwallet::data::{SaplingNoteData, WalletTx};
 
@@ -203,8 +203,7 @@ async fn basic_no_wallet_transactions() {
         mine_random_blocks(&mut fcbl, &data, &lc, 10).await;
         assert_eq!(lc.wallet.last_scanned_height().await, 10);
 
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -343,8 +342,7 @@ async fn z_incoming_z_outgoing() {
         assert_eq!(notes["spent_notes"][0]["spent_at_height"].as_u64().unwrap(), 17);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -499,8 +497,7 @@ async fn multiple_incoming_same_transaction() {
         assert_eq!(transactions[4]["outgoing_metadata"][0]["memo"].is_null(), true);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -556,8 +553,7 @@ async fn z_incoming_multiz_outgoing() {
         }
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -622,8 +618,7 @@ async fn z_to_z_scan_together() {
         assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), spent_value);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -721,8 +716,7 @@ async fn z_incoming_viewkey() {
         assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), sent_value);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -822,8 +816,7 @@ async fn t_incoming_t_outgoing() {
         );
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -926,8 +919,7 @@ async fn mixed_transaction() {
         );
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1046,8 +1038,7 @@ async fn aborted_resync() {
         }
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1103,8 +1094,7 @@ async fn no_change() {
         assert_eq!(notes["spent_utxos"][0]["spent"], sent_transaction_id);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1191,8 +1181,7 @@ async fn recover_at_checkpoint() {
         // );
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1299,8 +1288,7 @@ async fn witness_clearing() {
         assert_eq!(witnesses.len(), 0);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1413,8 +1401,7 @@ async fn mempool_clearing() {
         assert_eq!(transactions.len(), 1);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1485,8 +1472,7 @@ async fn mempool_and_balance() {
         assert_eq!(bal["unverified_zbalance"].as_u64().unwrap(), 0);
 
         // Shutdown everything cleanly
-        stop_transmitter.send(()).unwrap();
-        h1.await.unwrap();
+        clean_shutdown(stop_transmitter, h1).await;
     }
 }
 
@@ -1526,8 +1512,7 @@ async fn read_write_block_data() {
         cb.write(&mut *block_bytes).unwrap();
         assert_eq!(cb, crate::lightwallet::data::BlockData::read(&*block_bytes).unwrap());
     }
-    stop_transmitter.send(()).unwrap();
-    h1.await.unwrap();
+    clean_shutdown(stop_transmitter, h1).await;
 }
 
 pub const EXT_TADDR: &str = "t1NoS6ZgaUTpmjkge2cVpXGcySasdYDrXqh";

--- a/lib/src/lightwallet.rs
+++ b/lib/src/lightwallet.rs
@@ -1447,7 +1447,7 @@ mod test {
     use crate::{
         blaze::test_utils::{incw_to_string, FakeCompactBlockList, FakeTransaction},
         lightclient::{
-            test_server::{create_test_server, mine_pending_blocks, mine_random_blocks},
+            test_server::{clean_shutdown, create_test_server, mine_pending_blocks, mine_random_blocks},
             LightClient,
         },
     };
@@ -1576,8 +1576,7 @@ mod test {
             assert_eq!(utxos.len(), 1);
 
             // Shutdown everything cleanly
-            stop_transmitter.send(()).unwrap();
-            h1.await.unwrap();
+            clean_shutdown(stop_transmitter, h1).await;
         }
     }
 
@@ -1647,8 +1646,7 @@ mod test {
             assert_eq!(utxos.len(), 0);
 
             // Shutdown everything cleanly
-            stop_transmitter.send(()).unwrap();
-            h1.await.unwrap();
+            clean_shutdown(stop_transmitter, h1).await;
         }
     }
 }


### PR DESCRIPTION
The test server spawns a thread that must be
shutdown, then the server must be shutdown.
These things must always happen together and in
order.