### PR TITLE
WIP: change librustzcash dependency to track main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "bech32 0.8.1",
  "bs58",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "base64",
  "bech32 0.8.1",
@@ -3275,20 +3275,22 @@ dependencies = [
  "jubjub",
  "log",
  "nom",
+ "orchard",
  "percent-encoding",
  "protobuf",
  "protobuf-codegen-pure",
  "rand_core",
  "subtle",
  "time 0.2.27",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76)",
+ "zcash_address",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?branch=main)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3309,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -3320,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "aes",
  "bip0039 0.9.0",
@@ -3351,13 +3353,13 @@ dependencies = [
  "sha2 0.9.9",
  "subtle",
  "zcash_encoding",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?branch=main)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76#73d9395c9d3c5fa81fc7becd363a2c1a51772a76"
+source = "git+https://github.com/zcash/librustzcash?branch=main#3f5ba8de4823921092ab52a3e22e2516154f69b1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3422,7 +3424,7 @@ dependencies = [
  "zcash_address",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?branch=main)",
  "zcash_primitives",
  "zcash_proofs",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -51,12 +51,12 @@ group = "0.12"
 rust-embed = { version = "6.3.0", features = ["debug-embed"] }
 orchard = "0.1.0"
 subtle = "2.4.1"
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76"}
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76", features = ["transparent-inputs", "test-dependencies"] }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76"}
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76", features = ["multicore"]}
-zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76"}
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76", features = ["pre-zip-212"]}
+zcash_address = { git = "https://github.com/zcash/librustzcash", branch = "main" } 
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", branch = "main", features = ["transparent-inputs", "test-dependencies"] }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", branch = "main" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", branch = "main", features = ["multicore"] }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", branch = "main" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash", branch = "main", features = ["pre-zip-212"] }
 
 [dev-dependencies]
 portpicker = "0.1.0"


### PR DESCRIPTION
WIP, doesn't build!

fixes #79

This currently resolves to `3f5ba8de4823921092ab52a3e22e2516154f69b1`, though it will dynamically point to the most recent commit in the `main` branch from https://github.com/zcash/librustzcash/

See #79 for details